### PR TITLE
Add PolyBench/C

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,8 +166,6 @@ jobs:
           # with the faasm_sm_reduce signature
           # ./bin/inv_wrapper.sh run.pool kernels-omp random --cmdline '32 20'
       - name: "Run PolyBench/C"
-        # TODO: support WAMR too
-        # if: "contains(env.WASM_VM, 'wavm')"
         # We deliberately enumerate all the supported functions here and
         # execute them individually, rather than using the microbench runner.
         # This is so that we can more easily track what functions are supported

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,8 @@ jobs:
         run: ./bin/inv_wrapper.sh lulesh lulesh --native
       - name: "Build TensorFlow"
         run: ./bin/inv_wrapper.sh tensorflow
+      - name: "Build PolyBench/C"
+        run: ./bin/inv_wrapper.sh polybench polybench --native
       - name: "Build functions used in the tests"
         run: ./bin/inv_wrapper.sh func.tests
       - name: "Upload examples wasm"
@@ -118,6 +120,7 @@ jobs:
         run: |
           ./bin/inv_wrapper.sh codegen.user kernels-mpi
           ./bin/inv_wrapper.sh codegen.user kernels-omp
+          ./bin/inv_wrapper.sh codegen.user polybench
           ./bin/inv_wrapper.sh codegen imagemagick main
           ./bin/inv_wrapper.sh codegen lammps main
           ./bin/inv_wrapper.sh codegen lulesh main
@@ -162,6 +165,37 @@ jobs:
           # The random OpenMP kernel can not be cross-compiled due to a problem
           # with the faasm_sm_reduce signature
           # ./bin/inv_wrapper.sh run.pool kernels-omp random --cmdline '32 20'
+      - name: "Run PolyBench/C"
+        # TODO: support WAMR too
+        # if: "contains(env.WASM_VM, 'wavm')"
+        # We deliberately enumerate all the supported functions here and
+        # execute them individually, rather than using the microbench runner.
+        # This is so that we can more easily track what functions are supported
+        # and what functions are not
+        run: |
+          ./bin/inv_wrapper.sh run polybench poly_covariance
+          ./bin/inv_wrapper.sh run polybench poly_correlation
+          ./bin/inv_wrapper.sh run polybench poly_2mm
+          ./bin/inv_wrapper.sh run polybench poly_3mm
+          ./bin/inv_wrapper.sh run polybench poly_atax
+          ./bin/inv_wrapper.sh run polybench poly_bicg
+          ./bin/inv_wrapper.sh run polybench poly_doitgen
+          ./bin/inv_wrapper.sh run polybench poly_mvt
+          ./bin/inv_wrapper.sh run polybench poly_cholesky
+          ./bin/inv_wrapper.sh run polybench poly_durbin
+          ./bin/inv_wrapper.sh run polybench poly_gramschmidt
+          ./bin/inv_wrapper.sh run polybench poly_lu
+          ./bin/inv_wrapper.sh run polybench poly_ludcmp
+          ./bin/inv_wrapper.sh run polybench poly_trisolv
+          ./bin/inv_wrapper.sh run polybench poly_deriche
+          ./bin/inv_wrapper.sh run polybench poly_floyd-warshall
+          ./bin/inv_wrapper.sh run polybench poly_nussinov
+          ./bin/inv_wrapper.sh run polybench poly_adi
+          ./bin/inv_wrapper.sh run polybench poly_fdtd-2d
+          ./bin/inv_wrapper.sh run polybench poly_heat-3d
+          ./bin/inv_wrapper.sh run polybench poly_jacobi-1d
+          ./bin/inv_wrapper.sh run polybench poly_jacobi-2d
+          ./bin/inv_wrapper.sh run polybench poly_seidel-2d
       - name: "Run ImageMagick"
         if: "contains(env.WASM_VM, 'wavm')"
         run: ./bin/inv_wrapper.sh run imagemagick main --cmdline 'faasm://im/sample_image.png -flip faasm://im/image_out.png'

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,3 +36,6 @@
 	path = examples/lammps-migration
 	url = https://github.com/faasm/lammps.git
 	branch = faasm-migration
+[submodule "examples/polybench"]
+	path = examples/polybench
+	url = git@github.com:faasm/polybench.git

--- a/docker/build.dockerfile
+++ b/docker/build.dockerfile
@@ -55,6 +55,7 @@ RUN mkdir -p code \
     && git submodule update --init -f examples/lammps-migration \
     && git submodule update --init -f examples/LULESH \
     && git submodule update --init -f examples/libpng \
+    && git submodule update --init -f examples/polybench \
     && git submodule update --init -f examples/tensorflow
 
 # Build the examples and demo functions
@@ -67,6 +68,7 @@ RUN cd /code/examples \
         lammps --native \
         lammps --migration --native \
         lulesh --native \
+        polybench --native \
     && inv \
         ffmpeg \
         # ImageMagick needs libpng
@@ -75,6 +77,7 @@ RUN cd /code/examples \
         lammps \
         lammps --migration \
         lulesh \
+        polybench \
         tensorflow \
     # These demo functions link with the cross-compiled static libraries
     && inv \

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -12,6 +12,7 @@ from . import kernels
 from . import lammps
 from . import libpng
 from . import lulesh
+from . import polybench
 from . import tensorflow
 from . import wasm
 
@@ -28,6 +29,7 @@ ns = Collection(
     lammps,
     libpng,
     lulesh,
+    polybench,
     tensorflow,
     wasm,
 )

--- a/tasks/polybench.py
+++ b/tasks/polybench.py
@@ -50,9 +50,18 @@ def build(ctx, clean=False, native=False):
     work_env.update(FAASM_BUILD_ENV_DICT)
 
     run(cmake_cmd, shell=True, check=True, cwd=build_dir, env=work_env)
-    run("cmake --build . --target polybench_all", shell=True, check=True, cwd=build_dir)
+    run(
+        "cmake --build . --target polybench_all",
+        shell=True,
+        check=True,
+        cwd=build_dir,
+    )
 
     if not native:
         # Copy all the functions to /usr/local/faasm/wasm/polybench/*
-        for poly_func in [f for f in listdir(build_dir) if f.startswith("poly_")]:
-            wasm_copy_upload("polybench", poly_func, join(build_dir, poly_func))
+        for poly_func in [
+            f for f in listdir(build_dir) if f.startswith("poly_")
+        ]:
+            wasm_copy_upload(
+                "polybench", poly_func, join(build_dir, poly_func)
+            )

--- a/tasks/polybench.py
+++ b/tasks/polybench.py
@@ -1,0 +1,58 @@
+from faasmtools.build import CMAKE_TOOLCHAIN_FILE, FAASM_BUILD_ENV_DICT
+from faasmtools.compile_util import wasm_copy_upload
+from faasmtools.env import LLVM_VERSION
+from tasks.env import EXAMPLES_DIR
+from invoke import task
+from os import environ, listdir, makedirs
+from os.path import exists, join
+from shutil import rmtree
+from subprocess import run
+
+
+@task(default=True)
+def build(ctx, clean=False, native=False):
+    """
+    Build the PolyBench/C benchmark
+    """
+    polybench_dir = join(EXAMPLES_DIR, "polybench")
+    if native:
+        build_dir = join(polybench_dir, "build", "native")
+    else:
+        build_dir = join(polybench_dir, "build", "wasm")
+
+    if clean and exists(build_dir):
+        rmtree(build_dir)
+
+    if not exists(build_dir):
+        makedirs(build_dir)
+
+    cmake_cmd = [
+        "cmake",
+        "-GNinja",
+        "-DCMAKE_BUILD_TYPE=Release",
+    ]
+
+    if native:
+        llvm_major = LLVM_VERSION.split(".")[0]
+        cmake_cmd += [
+            "-DCMAKE_C_COMPILER=/usr/bin/clang-{}".format(llvm_major),
+            "-DCMAKE_CXX_COMPILER=/usr/bin/clang++-{}".format(llvm_major),
+        ]
+    else:
+        cmake_cmd += [
+            "-DFAASM_BUILD_TYPE=wasm",
+            "-DCMAKE_TOOLCHAIN_FILE={}".format(CMAKE_TOOLCHAIN_FILE),
+        ]
+    cmake_cmd += [polybench_dir]
+    cmake_cmd = " ".join(cmake_cmd)
+
+    work_env = environ.copy()
+    work_env.update(FAASM_BUILD_ENV_DICT)
+
+    run(cmake_cmd, shell=True, check=True, cwd=build_dir, env=work_env)
+    run("cmake --build . --target polybench_all", shell=True, check=True, cwd=build_dir)
+
+    if not native:
+        # Copy all the functions to /usr/local/faasm/wasm/polybench/*
+        for poly_func in [f for f in listdir(build_dir) if f.startswith("poly_")]:
+            wasm_copy_upload("polybench", poly_func, join(build_dir, poly_func))


### PR DESCRIPTION
The cross-compilation and execution of the PolyBench/C benchmark is a bit scattered all over the organisation. 

It first lived in the old [faasm-experiments](https://github.com/faasm/faasm-experiments/tree/master/func/polybench), which is now archived. Then, we resurrected it in [experiment-microbench](https://github.com/faasm/experiment-microbench/tree/main).

However, following the latest repo organisation, the `experiment-*` repositories should not contain scripts to cross-compile applications to WASM; only scripts to run and plot a very particular experiment. All application cross-compilation should happen in this repository (tightly bound to `faasm/cpp`). This is to ensure that we have a single-source of truth for our cross-compilation toolchain.

Thus, in this PR I move the cross-compilation of `PolyBench/C` to this repository.